### PR TITLE
Add Regio Aachen

### DIFF
--- a/config.toml
+++ b/config.toml
@@ -8,6 +8,9 @@ ignore_node = "3d"
 # dataPaths
 
 dataPaths = [
+	# aachen + regio aachen
+	"https://data.aachen.freifunk.net/new/nodes.json",
+	
 	# bremen
 	"https://downloads.bremen.freifunk.net/data/meshviewer.json",
 


### PR DESCRIPTION
This adds the (experimental) yanic nodes.json output from the Regio Aachen to the multi-meshviewer map.

This will add approx. 2100 nodes to the map.