### PR TITLE
Fix URL for Freifunk Vogtland

### DIFF
--- a/config.toml
+++ b/config.toml
@@ -158,7 +158,7 @@ dataPaths = [
 	"https://map.ffue.eu/data/meshviewer.json",
 
 	## Vogtland
-	"https://vpn01.freifunk-vogtland.net/ffv/meshviewer.json",
+	"https://mapdata.freifunk-vogtland.net/meshviewer.json",
 	
 	## Winterberg
 	"https://map.freifunk-winterberg.net/data/wtbg/meshviewer.json",


### PR DESCRIPTION
vpn01.freifunk-vogtland.net was the server which previously gathered the data. This job was now taken over by vpn04.freifunk-vogtland.net. For this reason, the CNAME mapdata.freifunk-vogtland.net should be used to refer to the server which provides map related data for Freifunk Vogtland.