### PR TITLE
Make Uptime positive.

### DIFF
--- a/converter/main.go
+++ b/converter/main.go
@@ -103,7 +103,7 @@ func (conv *Converter) Node(node *meshviewerFFRGB.Node, name string) (*yanicRunt
 		},
 		Statistics: &yanicData.Statistics{
 			NodeID: node.NodeID,
-			Uptime: float64(node.Uptime.Unix() - now.Unix()),
+			Uptime: float64(now.Unix() - node.Uptime.Unix()),
 			Clients: yanicData.Clients{
 				Total:  node.Clients,
 				Wifi:   node.Clients - node.ClientsOthers,


### PR DESCRIPTION
The uptime timestamp is a timestamp in the past.
That means now.Unix() is a newwer timestamp than node.Uptime.Unix().
Currently the logic we end up with following uptime values in json:
  "2020-05-31T07:00:59+0200"

and those do not make sense at all.